### PR TITLE
Rename robot overview

### DIFF
--- a/docs/getting_started/stretch_hardware_overview.md
+++ b/docs/getting_started/stretch_hardware_overview.md
@@ -1,4 +1,4 @@
-# Stretch Hardware Overview
+# Robot Overview
 
 This guide will walk you through Stretch's hardware from top to bottom, including some simple command line tools you can use to interact with the robot.
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -315,7 +315,7 @@
         </h2>
         <a href="getting_started/hello_robot/">Hello Robot!</a>
         <a href="getting_started/connecting_to_stretch/">Connecting to Stretch</a>
-        <a href="getting_started/stretch_hardware_overview/">Stretch Hardware Overview</a>
+        <a href="getting_started/stretch_hardware_overview/">Robot Overview</a>
         <a href="getting_started/writing_code/">Writing Code</a>
         <a href="getting_started/demos_mapping_and_navigation/">Demos</a>
         <a href="getting_started/community_resources/">Community Resources</a>


### PR DESCRIPTION
This PR renames "Stretch Hardware Overview" to "Robot Overview". This reduces confusion between this and "Stretch 3 Hardware Guide".

To prevent 404s, the URL is not changed.