### PR TITLE
Edit Page Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ mike deploy 0.3 'experimental' -t '0.3: Experimental development' --push
 ```
 
 Note the format for the title (-t). Keep a consistent naming structure. Also note that this version is aliased as `experimental`. 
+
+Also, edit the edit_uri in mkdocs.yml to have the new version as a branch name.
+
 ## Adding a New Submodule Repo
 ```commandline
 cd ~/repos/hello-robot.github.io/repos

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,8 @@ site_description: "Hello Robot User Documentation"
 copyright: 'Copyright &copy; 2020-2025 Hello Robot Inc'
 site_author: Hello Robot Inc
 use_directory_urls: True
-edit_uri: ''
+repo_url: https://github.com/hello-robot/hello-robot.github.io
+edit_uri: blob/0.3/docs
 
 theme:
  name: material
@@ -18,6 +19,7 @@ theme:
   - scheme: default
     primary: hello-robot-light
  features:
+   - content.action.edit
    - navigation.footer
 
 extra_css:
@@ -51,6 +53,9 @@ plugins:
       skip_classes:
         - glightbox-skip
   - include-markdown
+
+hooks:
+  - plugins/edit_links_across_submodules.py
 
 extra:
   version:

--- a/plugins/edit_links_across_submodules.py
+++ b/plugins/edit_links_across_submodules.py
@@ -1,0 +1,64 @@
+"""
+Replaces the edit_url for documentation included in other submodules.
+
+For example, the file robot_parameters.md [1] is included using the submodule located at repos/stretch_body
+
+When edit_uri is defined in the mkdocs.yml, the edit link for that page is
+https://github.com/hello-robot/hello-robot.github.io/blob/0.3/repos/stretch_body/docs/robot_parameters.md
+which does not link properly.
+
+The code contained in this module is inspired by the submodule-edit-uri plugin [2]
+and uses the mkdocs hooks [3] functionality.
+
+It reads the submodules from `.gitmodules` using GitPython during the configuration step,
+and then substitutes the proper url in the full output.
+
+The resulting link is now correct, linking to the full github blob url [1]
+
+[1] https://github.com/hello-robot/stretch_body/blob/master/docs/robot_parameters.md
+[2] https://github.com/sondregronas/mkdocs-submodule-edit-uri
+[3] https://www.mkdocs.org/user-guide/configuration/#hooks
+
+
+"""
+from git import Repo
+
+
+def urljoin(*a):
+    s = ''
+    for sub in a:
+        if s and not s.endswith('/'):
+            s += '/'
+        s += sub
+    return s
+
+
+def on_config(config):
+    submod_d = {}
+    config['submodules'] = submod_d
+    repo = Repo('.')
+    for submod in repo.submodules:
+        url = submod.url
+        if url.endswith('.git'):
+            url = url[:-4]
+        submod_d[submod.name] = {
+            'path': submod.path,
+            'url': url,
+            'branch': submod.branch.name,
+        }
+
+
+def on_post_page(output, page, config):
+    # Assume that the edit uri is (blob|edit)/(branch_name)/docs/
+    edit_pieces = config['edit_uri'].split('/')
+    assert len(edit_pieces) == 4, config['edit_uri']
+    verb = edit_pieces[0]
+    branch = edit_pieces[1]
+
+    base = urljoin(config['repo_url'], verb, branch)
+
+    for name, submod in config['submodules'].items():
+        old_path = urljoin(base, submod['path'])
+        new_path = urljoin(submod['url'], verb, submod['branch'])
+        output = output.replace(old_path, new_path)
+    return output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "This repository generates the documentation hosted at [docs.hello
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "GitPython>3.1",
     "jinja2==3.0.3",
     "mike>=2.1.3",
     "mkdocs>=1.6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -404,10 +404,35 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.45"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+]
+
+[[package]]
 name = "hello-robot-github-io"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "gitpython" },
     { name = "jinja2" },
     { name = "mike" },
     { name = "mkdocs" },
@@ -426,6 +451,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gitpython", specifier = ">3.1" },
     { name = "jinja2", specifier = "==3.0.3" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs", specifier = ">=1.6.1" },
@@ -1685,6 +1711,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds an edit page button to all content pages on [docs.hello-robot.com](https://docs.hello-robot.com/0.3/) including those included through submodules. 

## Demo

https://github.com/user-attachments/assets/6e080747-7adb-4628-b068-1f506b96abc5



## Notes
 * If only the changes to `mkdocs.yml` were included (without the `hooks` part), the edit button would appear on all the pages, but have the inappropriate link for most of them. 
 * I wanted there to be a way to have the `edit_uri` configuration not be hard-coded to the branch name, but the [`edit_uri_template`](https://www.mkdocs.org/user-guide/configuration/#edit_uri_template) variable has very limited fields to include.
 * This PR adds a dependency on the Python library `GitPython`, which is not strictly necessary, but easier than parsing `.gitmodules` by hand. 
 * I have included the associated `uv.lock` changes that were autogenerated, but I'm not super familiar with its intricacies. 