### PR TITLE
add navigation note for 0.3

### DIFF
--- a/docs/getting_started/demos_mapping_and_navigation.md
+++ b/docs/getting_started/demos_mapping_and_navigation.md
@@ -56,6 +56,9 @@ This will save two files to the "~/stretch_user/maps" directory - `nav2_demo_map
 
 ### Navigation
 
+!!! note
+    Before starting navigation, ensure that the mapping process (`offline_mapping.launch.py`) has been stopped. Navigation should be launched after mapping is complete and the map has been saved.
+    
 Now that we have a saved map of the environment, we can command the robot to move around the mapped space. Run the following command:
 
 ```{.bash .shell-prompt .copy}


### PR DESCRIPTION
Adds a note clarifying that mapping and navigation are separate steps, and that navigation should be launched only after mapping has completed, been stopped, and the map has been saved.